### PR TITLE
Add PHP figurine database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ $RECYCLE.BIN/
 
 # Linux
 *~
+# Database
+figurines.db
+

--- a/add_figurine.php
+++ b/add_figurine.php
@@ -1,0 +1,30 @@
+<?php
+require_once 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $status = $_POST['status'] ?? 'trade';
+    $price = floatval($_POST['price'] ?? 0);
+    $user = trim($_POST['user'] ?? 'anonymous');
+
+    if ($name === '') {
+        http_response_code(400);
+        echo "Name is required";
+        exit;
+    }
+
+    if (!in_array($status, ['trade','sell','buy'])) {
+        http_response_code(400);
+        echo "Invalid status";
+        exit;
+    }
+
+    $db = get_db();
+    $stmt = $db->prepare('INSERT INTO figurines (name, description, status, price, user) VALUES (?, ?, ?, ?, ?)');
+    $stmt->execute([$name, $description, $status, $price, $user]);
+    echo "Figurine added";
+} else {
+    echo "Use POST";
+}
+?>

--- a/db.php
+++ b/db.php
@@ -1,0 +1,16 @@
+<?php
+function get_db(){
+    $db = new PDO('sqlite:' . __DIR__ . '/figurines.db');
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $db->exec("CREATE TABLE IF NOT EXISTS figurines (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        description TEXT,
+        status TEXT CHECK(status IN ('trade','sell','buy')) NOT NULL,
+        price REAL,
+        user TEXT NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )");
+    return $db;
+}
+?>

--- a/list_figurines.php
+++ b/list_figurines.php
@@ -1,0 +1,17 @@
+<?php
+require_once 'db.php';
+
+$db = get_db();
+$status = $_GET['status'] ?? null;
+
+if ($status && in_array($status, ['trade','sell','buy'])) {
+    $stmt = $db->prepare('SELECT * FROM figurines WHERE status = ? ORDER BY created_at DESC');
+    $stmt->execute([$status]);
+} else {
+    $stmt = $db->query('SELECT * FROM figurines ORDER BY created_at DESC');
+}
+
+$figurines = $stmt->fetchAll(PDO::FETCH_ASSOC);
+header('Content-Type: application/json');
+echo json_encode($figurines);
+?>


### PR DESCRIPTION
## Summary
- create SQLite database connection
- add endpoint for adding figurines
- add endpoint for listing figurines
- ignore database file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cbcba38788330be8cfc071a76ae80