### PR TITLE
Add PHP profile database

### DIFF
--- a/add_profile.php
+++ b/add_profile.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/db.php';
+$db = getDbConnection();
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $bio = trim($_POST['bio'] ?? '');
+
+    if ($username !== '' && $email !== '') {
+        $stmt = $db->prepare('INSERT INTO users (username, email, bio) VALUES (?, ?, ?)');
+        $stmt->execute([$username, $email, $bio]);
+        $message = 'Profile saved.';
+    } else {
+        $message = 'Username and email are required.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Add Profile</title>
+</head>
+<body>
+<h1>Add Profile</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<form method="post">
+    <label>Username: <input type="text" name="username" required></label><br>
+    <label>Email: <input type="email" name="email" required></label><br>
+    <label>Bio:<br><textarea name="bio" rows="4" cols="40"></textarea></label><br>
+    <button type="submit">Save</button>
+</form>
+<p><a href="profiles.php">View Profiles</a></p>
+</body>
+</html>

--- a/db.php
+++ b/db.php
@@ -1,0 +1,14 @@
+<?php
+function getDbConnection(): PDO {
+    $db = new PDO('sqlite:' . __DIR__ . '/profiles.db');
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $db->exec("CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL,
+        email TEXT NOT NULL,
+        bio TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )");
+    return $db;
+}
+?>

--- a/profile.html
+++ b/profile.html
@@ -218,6 +218,10 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at augue quis purus luctus varius. Suspendisse potenti.</p>
       </div>
     </div>
+    <div class="php-links" style="margin: 1rem 0; text-align: center;">
+      <a href="add_profile.php">Add Profile</a> |
+      <a href="profiles.php">View Profiles</a>
+    </div>
   </main>
 </body>
 </html>

--- a/profiles.php
+++ b/profiles.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/db.php';
+$db = getDbConnection();
+$stmt = $db->query('SELECT username, email, bio, created_at FROM users ORDER BY created_at DESC');
+$profiles = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>User Profiles</title>
+</head>
+<body>
+<h1>User Profiles</h1>
+<p><a href="add_profile.php">Add New Profile</a></p>
+<table border="1" cellpadding="5">
+    <tr>
+        <th>Username</th>
+        <th>Email</th>
+        <th>Bio</th>
+        <th>Created</th>
+    </tr>
+<?php foreach ($profiles as $p): ?>
+    <tr>
+        <td><?php echo htmlspecialchars($p['username']); ?></td>
+        <td><?php echo htmlspecialchars($p['email']); ?></td>
+        <td><?php echo nl2br(htmlspecialchars($p['bio'])); ?></td>
+        <td><?php echo htmlspecialchars($p['created_at']); ?></td>
+    </tr>
+<?php endforeach; ?>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `db.php` to set up a SQLite database
- add `add_profile.php` to store submitted user data
- add `profiles.php` to list saved profiles
- link to the new PHP pages from `profile.html`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cbc9545d88330b08ba7f8e0ae1719